### PR TITLE
test github context printing why

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,6 @@ jobs:
       - name: Check commit message
         run: |
           echo PR #${{ github.event.number }} has been merged
-          echo ${{ toJSON(github.event.pull_request.head.sha) }}
-          echo ${{ toJSON(github.event.pull_request) }}
           echo ::set-env name=commitmsg_temp::$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }})
           echo ::set-env name=commitmsg::$(git log --format=%B -n 1 ${{ github.event.after }})
           echo "temp " $commitmsg_temp
@@ -28,3 +26,5 @@ jobs:
           echo "github.event.head_commit.message " ${{ toJSON(github.event.head_commit.message) }}
           echo "github.event.commits[0].message " ${{ toJSON(github.event.commits[0].message) }}
           echo "github.event.head_commit.message " ${{ toJSON(github.event.head_commit.message) }}
+          echo ${{ toJSON(github.event.pull_request.head.sha) }}
+          echo ${{ toJSON(github.event.pull_request) }}


### PR DESCRIPTION
Signed-off-by: Deepika Upadhyay <dupadhya@redhat.com>


<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test classic perf`
- `jenkins test crimson perf`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard cephadm`
- `jenkins test api`
- `jenkins test docs`
- `jenkins render docs`
- `jenkins test ceph-volume all`
- `jenkins test ceph-volume tox`

</details>
